### PR TITLE
fixed read_table fxn for single-column tables

### DIFF
--- a/R/zzz.r
+++ b/R/zzz.r
@@ -207,9 +207,11 @@ read_upwell <- function(x){
 
 read_table <- function(x){
   if(is(x, "response")) {
-    read.csv(text = content(x, "text"), sep = ",", stringsAsFactors=FALSE)[-1,]
+    read.csv(text = content(x, "text"), sep = ",", stringsAsFactors=FALSE,
+             blank.lines.skip=FALSE)[-1, , drop=FALSE]
   } else {  
-    read.delim(x, sep=",", stringsAsFactors=FALSE)[-1,]
+    read.delim(x, sep=",", stringsAsFactors=FALSE,
+               blank.lines.skip=FALSE)[-1, , drop=FALSE]
   }
 }
 


### PR DESCRIPTION
There is a bug in the read_table fxn when a single column is queried. To see the problem, try (e.g., which cruises are available in this table?):

erddap_table(x='erdCalCOFIeggcntpos', store=memory(),
             fields=c('cruise'), orderby='cruise', distinct=TRUE)

This is caused by the "[-1,]" used to remove the initial blank record in the read statements. Two changes are needed. First, that blank line doesn't occur in single-column tables. So the read functions need to use "blank.lines.skip=FALSE" to prevent a valid row from being removed in single-column queries. Second, need to add "drop=FALSE" to the bracket selection so that single-column results aren't reduced to vectors. 
