### PR TITLE
fixed erddap_tab_GET fxn to honor disk$overwrite=T

### DIFF
--- a/R/erddap_table.R
+++ b/R/erddap_table.R
@@ -171,7 +171,7 @@ print.erddap_table <- function(x, ..., n = 10){
 erd_tab_GET <- function(url, dset, store, ...){
   if(store$store == "disk"){
     fpath <- path.expand(file.path(store$path, paste0(dset, ".csv")))
-    if( file.exists( fpath ) ){ fpath } else {
+    if( file.exists( fpath ) & store$overwrite == FALSE){ fpath } else {
       dir.create(store$path, showWarnings = FALSE, recursive = TRUE)
       res <- GET(url, write_disk(writepath(store$path, dset), store$overwrite), ...)
       out <- check_response_erddap(res)


### PR DESCRIPTION
The "disk(overwrite=T)" currently  is not honored in the erddap_table fxn. So if a user changes his mind about a table saved to disk, he has to delete the file before getting new data. For example:
# initial table

cruises <- erddap_table(x='erdCalCOFIeggcntpos', fields=c('cruise'),
                        orderby='cruise', distinct=TRUE)
cruises
# oops, I forgot I wanted cruise and ship, default is overwrite=T

cruises <- erddap_table(x='erdCalCOFIeggcntpos', fields=c('cruise', 'ship'),
                        orderby=c('cruise', 'ship'), distinct=TRUE)
# nope, still reading the existing file instead of overwriting

cruises
