### PR TITLE
fixed erddap_table fxn to query fields with spaces

### DIFF
--- a/R/erddap_table.R
+++ b/R/erddap_table.R
@@ -150,6 +150,7 @@ erddap_table <- function(x, ..., fields=NULL, distinct=FALSE, orderby=NULL,
   if(!nchar(args[[1]]) == 0){
     url <- paste0(url, '&', args)
   }
+  url <- gsub(' ', '%20', url)
   resp <- erd_tab_GET(url, dset=attr(x, "datasetid"), store, callopts)
   loc <- if(store$store == "disk") resp else "memory"
   structure(read_table(resp), class=c("erddap_table","data.frame"), datasetid=attr(x, "datasetid"), path=loc)


### PR DESCRIPTION
queries on fields that contain spaces currently cause the erddap_table fxn to puke, e.g.:

ccdat <- erddap_table('erdCalCOFIeggcntpos', store=memory(),
                      'cruise="201004"',
                      'scientific_name="Sardinops sagax"')
