### PR TITLE
Coerce coops results to numeric, account for data results not named "data", add examples

### DIFF
--- a/R/coops.R
+++ b/R/coops.R
@@ -64,20 +64,65 @@
 #' coops_search(station_name = 8723970, begin_date = 19820301, end_date = 20141001,
 #'  datum = "stnd", product = "monthly_mean")
 #'  
-#' # Get verified water level data at Vaca Key (2723970)
+#' # Get verified water level data at Vaca Key (8723970)
 #' coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
 #'  datum = "stnd", product = "water_level")
 #'  
 #' # Get daily mean water level data at Fairport, OH (9063053)
-#'  coops_search(station_name = 9063053, begin_date = 20150927, end_date = 20150928, product = "daily_mean", datum = "stnd"), time_zone = "lst")
+#'  coops_search(station_name = 9063053, begin_date = 20150927, end_date = 20150928,
+#'   product = "daily_mean", datum = "stnd"), time_zone = "lst")
 #'  
-#' # Get air temperature at Vaca Key (2723970)
+#' # Get air temperature at Vaca Key (8723970)
 #' coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
 #'  product = "air_temperature")
 #' 
-#' # Get water temperature at Vaca Key (2723970)
+#' # Get water temperature at Vaca Key (8723970)
 #' coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
 #'  product = "water_temperature")
+#'  
+#' # Get air pressure at Vaca Key (8723970)
+#' coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
+#'  product = "air_pressure")
+#' 
+#' # Get conductivity at Eugene Island, LA (8764314)
+#' coops_search(station_name = 8764314, begin_date = 20151223, end_date = 20151224,
+#'  product = "conductivity")
+#' 
+#' # Get salinity at Eugene Island, LA (8764314)
+#' coops_search(station_name = 8764314, begin_date = 20150927, end_date = 20150928,
+#'  product = "salinity")
+#'  
+#' # Get humidity at Eugene Island, LA (8764314)
+#' coops_search(station_name = 8764314, begin_date = 20150927, end_date = 20150928,
+#'  product = "humidity")
+#'
+#' # Get wind at Vaca Key (8723970)
+#' coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
+#'  product = "wind")
+#'  
+#' # Get hourly water level height at Key West (8724580)
+#' coops_search(station_name = 8724580, begin_date = 20140927, end_date = 20140928,
+#'  product = "hourly_height", datum = "stnd")
+#'  
+#' # Get high-low water level at Key West (8724580)
+#' coops_search(station_name = 8724580, begin_date = 20140927, end_date = 20140928,
+#'  product = "high_low", datum = "stnd")
+#'  
+#' # Get currents data at Pascagoula Harbor (ps0401)
+#' coops_search(station_name = "ps0401", begin_date = 20151221, end_date = 20151222,
+#'  product = "currents")
+#'  
+#' # Get one-minute water level at Vaca Key (8723970)
+#' coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
+#'  datum = "stnd", product = "one_minute_water_level")
+#' 
+#' # Get datums at Fort Myers, FL (8725520)
+#' coops_search(station_name = 8725520, product = "datums")
+#' 
+#' # Get water level predictions at Vaca Key (8723970)
+#' coops_search(station_name = 8723970, begin_date = 20140928, end_date = 20140929,
+#'  datum = "stnd", product = "predictions")
+#' 
 #' }
 coops_search <- function(begin_date = NULL, end_date = NULL, station_name = NULL, 
                          product, datum = NULL, units = "metric", time_zone = "gmt", 

--- a/R/coops.R
+++ b/R/coops.R
@@ -68,6 +68,9 @@
 #' coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
 #'  datum = "stnd", product = "water_level")
 #'  
+#' # Get daily mean water level data at Fairport, OH (9063053)
+#'  coops_search(station_name = 9063053, begin_date = 20150927, end_date = 20150928, product = "daily_mean", datum = "stnd"), time_zone = "lst")
+#'  
 #' # Get air temperature at Vaca Key (2723970)
 #' coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
 #'  product = "air_temperature")
@@ -96,6 +99,16 @@ coops_search <- function(begin_date = NULL, end_date = NULL, station_name = NULL
       & is.null(nrow(res$datums))) {
     stop("No data was found", call. = FALSE)
   }
+  
+  if(!(product %in% c("monthly_mean", "datums"))){
+    res[[length(res)]][,1] <- as.POSIXct(res[[length(res)]][,1])
+  }
+  
+  if(product == "monthly_mean"){
+    res[[length(res)]] <- data.frame(apply(res[[length(res)]], 2, as.numeric))
+  }
+  
+  res[[length(res)]][,2] <- as.numeric(res[[length(res)]][,2])
   
   res
 }

--- a/R/coops.R
+++ b/R/coops.R
@@ -49,8 +49,12 @@
 #'  \item STND - Station datum
 #' }
 #'
-#' @references \url{http://co-ops.nos.noaa.gov/api/}
-#' @return List, of length two. 
+#' @references 
+#' \url{http://co-ops.nos.noaa.gov/api/}
+#' 
+#' \url{http://tidesandcurrents.noaa.gov/map/}
+#'  
+#' @return List, of length one or two. 
 #' \itemize{
 #'  \item metadata A list of metadata with slots id, name, lat, lon
 #'  \item data A data.frame with data
@@ -88,7 +92,8 @@ coops_search <- function(begin_date = NULL, end_date = NULL, station_name = NULL
 
   res <- coops_GET(coops_base(), args, ...)
 
-  if (is.null(nrow(res$data))) {
+  if (is.null(nrow(res$data)) & is.null(nrow(res$predictions))
+      & is.null(nrow(res$datums))) {
     stop("No data was found", call. = FALSE)
   }
   

--- a/R/coops.R
+++ b/R/coops.R
@@ -70,7 +70,7 @@
 #'  
 #' # Get daily mean water level data at Fairport, OH (9063053)
 #'  coops_search(station_name = 9063053, begin_date = 20150927, end_date = 20150928,
-#'   product = "daily_mean", datum = "stnd"), time_zone = "lst")
+#'   product = "daily_mean", datum = "stnd", time_zone = "lst")
 #'  
 #' # Get air temperature at Vaca Key (8723970)
 #' coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,

--- a/man/coops.Rd
+++ b/man/coops.Rd
@@ -30,7 +30,7 @@ organization. Optional}
 \item{...}{Curl options passed on to \code{\link[httr]{GET}}. Optional}
 }
 \value{
-List, of length two. 
+List, of length one or two. 
 \itemize{
  \item metadata A list of metadata with slots id, name, lat, lon
  \item data A data.frame with data
@@ -84,6 +84,9 @@ coops_search(station_name = 8723970, begin_date = 19820301, end_date = 20141001,
 # Get verified water level data at Vaca Key (2723970)
 coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
  datum = "stnd", product = "water_level")
+ 
+# Get daily mean water level data at Fairport, OH (9063053)
+ coops_search(station_name = 9063053, begin_date = 20150927, end_date = 20150928, product = "daily_mean", datum = "stnd"), time_zone = "lst")
  
 # Get air temperature at Vaca Key (2723970)
 coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,

--- a/man/coops.Rd
+++ b/man/coops.Rd
@@ -81,20 +81,65 @@ Options for the datum paramter. One of:
 coops_search(station_name = 8723970, begin_date = 19820301, end_date = 20141001,
  datum = "stnd", product = "monthly_mean")
  
-# Get verified water level data at Vaca Key (2723970)
+# Get verified water level data at Vaca Key (8723970)
 coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
  datum = "stnd", product = "water_level")
  
 # Get daily mean water level data at Fairport, OH (9063053)
- coops_search(station_name = 9063053, begin_date = 20150927, end_date = 20150928, product = "daily_mean", datum = "stnd"), time_zone = "lst")
+ coops_search(station_name = 9063053, begin_date = 20150927, end_date = 20150928,
+  product = "daily_mean", datum = "stnd"), time_zone = "lst")
  
-# Get air temperature at Vaca Key (2723970)
+# Get air temperature at Vaca Key (8723970)
 coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
  product = "air_temperature")
 
-# Get water temperature at Vaca Key (2723970)
+# Get water temperature at Vaca Key (8723970)
 coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
  product = "water_temperature")
+ 
+# Get air pressure at Vaca Key (8723970)
+coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
+ product = "air_pressure")
+
+# Get conductivity at Eugene Island, LA (8764314)
+coops_search(station_name = 8764314, begin_date = 20151223, end_date = 20151224,
+ product = "conductivity")
+
+# Get salinity at Eugene Island, LA (8764314)
+coops_search(station_name = 8764314, begin_date = 20150927, end_date = 20150928,
+ product = "salinity")
+ 
+# Get humidity at Eugene Island, LA (8764314)
+coops_search(station_name = 8764314, begin_date = 20150927, end_date = 20150928,
+ product = "humidity")
+
+# Get wind at Vaca Key (8723970)
+coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
+ product = "wind")
+ 
+# Get hourly water level height at Key West (8724580)
+coops_search(station_name = 8724580, begin_date = 20140927, end_date = 20140928,
+ product = "hourly_height", datum = "stnd")
+ 
+# Get high-low water level at Key West (8724580)
+coops_search(station_name = 8724580, begin_date = 20140927, end_date = 20140928,
+ product = "high_low", datum = "stnd")
+ 
+# Get currents data at Pascagoula Harbor (ps0401)
+coops_search(station_name = "ps0401", begin_date = 20151221, end_date = 20151222,
+ product = "currents")
+ 
+# Get one-minute water level at Vaca Key (8723970)
+coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
+ datum = "stnd", product = "one_minute_water_level")
+
+# Get datums at Fort Myers, FL (8725520)
+coops_search(station_name = 8725520, product = "datums")
+
+# Get water level predictions at Vaca Key (8723970)
+coops_search(station_name = 8723970, begin_date = 20140928, end_date = 20140929,
+ datum = "stnd", product = "predictions")
+
 }
 }
 \references{

--- a/man/coops.Rd
+++ b/man/coops.Rd
@@ -87,7 +87,7 @@ coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
  
 # Get daily mean water level data at Fairport, OH (9063053)
  coops_search(station_name = 9063053, begin_date = 20150927, end_date = 20150928,
-  product = "daily_mean", datum = "stnd"), time_zone = "lst")
+  product = "daily_mean", datum = "stnd", time_zone = "lst")
  
 # Get air temperature at Vaca Key (8723970)
 coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,

--- a/man/coops.Rd
+++ b/man/coops.Rd
@@ -96,5 +96,7 @@ coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
 }
 \references{
 \url{http://co-ops.nos.noaa.gov/api/}
+
+\url{http://tidesandcurrents.noaa.gov/map/}
 }
 


### PR DESCRIPTION
#126 Still unsure if I have coerced numeric results in the best way. The only consistent numeric column across all products is the second column. Here is a breakdown of the various column types:


> **18 col**
> #all numeric
> monthly_mean

> **5 col**
> #posix-date, numeric, numeric, character, character
> water_level

> **3 col**
> #posix-date, numeric, character; #only for great lakes stations
> daily_mean

> #posix-date, numeric, character
> air_temperature

> #posix-date, numeric, character
> water_temperature

> #posix-date, numeric, character
> air_pressure

> #posix-date, numeric, character
> conductivity

> #posix-date, numeric, numeric
> salinity

> #posix-date, numeric, character
> humidity

> **6 col**
> #posix-date, numeric, numeric, character, numeric, character
> wind

> **4 col**
> #posix-date, numeric, numeric, character
> hourly_height

> #posix-date, numeric, character, character
> high_low

> #posix-date and numerics
> currents

> **2 col**
> #posix-date and numeric
> one_minute_water_level

> #character and numeric
> datums

> #posix-date & numeric
> predictions

> **#no data at any station?**
> air_gap

> visibility
