### PR TITLE
Error trapping for excessive durations in coops_search() coops.R

### DIFF
--- a/R/coops.R
+++ b/R/coops.R
@@ -34,17 +34,22 @@
 #'  measure of atmospheric clarity
 #'  \item humidity - Relative humidity as measured at the station
 #'  \item salinity - Salinity and specific gravity data for the station
+#'  \item one_minute_water_level - One minute water level data for the station
+#'  \item predictions - 6 minute predictions water level data for the station
 #'  \item hourly_height - Verified hourly height water level data for
 #'  the station
 #'  \item high_low - Verified high/low water level data for the station
 #'  \item daily_mean - Verified daily mean water level data for the station
 #'  \item monthly_mean - Verified monthly mean water level data for the station
-#'  \item one_minute_water_level - One minute water level data for the station
-#'  \item predictions - 6 minute predictions water level data for the station
 #'  \item datums - datums data for the stations
 #'  \item currents - Currents data for currents stations
 #' }
 #'
+#' Maximum Durations in a Single Call:
+#' Products water_level through predictions allow requests for up to 31 days of data.
+#' Products hourly_heignt and high_low allow requests for up to 1 year (366 days) of data.
+#' Products daily_mean and monthly_mean allow requests for up to 10 years of data.
+# '
 #' Options for the datum paramter. One of:
 #' \itemize{
 #'  \item MHHW - Mean higher high water
@@ -135,7 +140,34 @@ coops_search <- function(begin_date = NULL, end_date = NULL,
   if (product %in% water_level_products & length(datum) < 1) {
     stop("Must specify a datum for water level products", call. = FALSE)
   }
-
+  
+  # check for duration longer than NOAA will return
+  group1_products <- c(                       # sub-hourly products with 31 day max
+    "water_level",  "air_temperature",  "water_temperature",  "wind", 
+    "air_pressure", "air_gap", "conductivity", "visibility", "humidity", 
+    "salinity", "one_minute_water_level", "predictions")
+                        )
+  group2_products <- c(                       # hourly to sub-daily products with 1 year max
+    "hourly_height", "high_low")
+  group3_products <- c(                       # daily or longer products with 10 year max
+    "daily_mean", "monthly_mean")
+  if (product %in% group1_products) {
+    maxdur <- 31
+  } else if (product %in% group2_products) {
+    maxdur <- 366
+  } else if (product %in% group3_products) {
+    maxdur <- 3653
+  } else maxdur <- 365000
+  
+  bd <- as.Date(as.character(begin_date),format="%Y%m%d")
+  ed <- as.Date(as.character(end_date),format="%Y%m%d")
+  req_dur <- ed - bd
+  if (req_dur > maxdur) {
+    stop(paste("The maximum duration NOAA API supports a single call for ", product, " is ", maxdur, "days\n", 
+               begin_date, " to ", end_date, " is ", req_dur, " days\n",sep=""), call. = FALSE)
+  }
+  # bottom check for too long of duration  
+    
   args <- noaa_compact(list(begin_date = begin_date, end_date = end_date,
                             station = station_name, product = product,
                             datum = datum, units = units, time_zone = time_zone,

--- a/R/coops.R
+++ b/R/coops.R
@@ -46,10 +46,14 @@
 #' }
 #'
 #' Maximum Durations in a Single Call:
-#' Products water_level through predictions allow requests for up to 31 days of data.
-#' Products hourly_heignt and high_low allow requests for up to 1 year (366 days) of data.
-#' Products daily_mean and monthly_mean allow requests for up to 10 years of data.
-# '
+#' \itemize{
+#' \item Products water_level through predictions allow requests for up to 
+#` 31 days of data.
+#' \item Products hourly_heignt and high_low allow requests for up to 
+#` 1 year (366 days) of data.
+#' \item Products daily_mean and monthly_mean allow requests for up to 
+#` 10 years of data.
+#' }#'
 #' Options for the datum paramter. One of:
 #' \itemize{
 #'  \item MHHW - Mean higher high water
@@ -142,14 +146,15 @@ coops_search <- function(begin_date = NULL, end_date = NULL,
   }
   
   # check for duration longer than NOAA will return
-  group1_products <- c(                       # sub-hourly products with 31 day max
-    "water_level",  "air_temperature",  "water_temperature",  "wind", 
-    "air_pressure", "air_gap", "conductivity", "visibility", "humidity", 
-    "salinity", "one_minute_water_level", "predictions", "currents")
+  group1_products <- c(           # sub-hourly products with 31 day max
+    "water_level",  "air_temperature",  "water_temperature",
+    "wind", "air_pressure", "air_gap", "conductivity", 
+    "visibility", "humidity", "salinity", "one_minute_water_level", 
+    "predictions", "currents")
                         
-  group2_products <- c(                       # hourly to sub-daily products with 1 year max
+  group2_products <- c(   # hourly to sub-daily products with 1 year max
     "hourly_height", "high_low")
-  group3_products <- c(                       # daily or longer products with 10 year max
+  group3_products <- c(      # daily or longer products with 10 year max
     "daily_mean", "monthly_mean")
   if (product %in% group1_products) {
     maxdur <- 31
@@ -159,13 +164,15 @@ coops_search <- function(begin_date = NULL, end_date = NULL,
     maxdur <- 3653
   } else maxdur <- 365000
   
-  if (!is.null(begin_date)&!is.null(end_date)) {
-    bd <- as.Date(as.character(begin_date),format="%Y%m%d")
-    ed <- as.Date(as.character(end_date),format="%Y%m%d")
+  if (!is.null(begin_date) && !is.null(end_date)) {
+    bd <- as.Date(as.character(begin_date), format = "%Y%m%d")
+    ed <- as.Date(as.character(end_date), format = "%Y%m%d")
     req_dur <- ed - bd
     if (req_dur > maxdur) {
-      stop(paste("The maximum duration NOAA API supports a single call for\n", product, " is ", maxdur, " days\n", 
-                 begin_date, " to ", end_date, " is ", req_dur, " days\n",sep=""), call. = FALSE)
+      stop(paste("The maximum duration the NOAA API allows in a",
+                 "single call for\n", product, " is ", maxdur, 
+                 " days\n", begin_date, " to ", end_date, " is ", 
+                 req_dur, " days\n", sep=""), call. = FALSE)
     } # if (req_dur > maxdur)
   } # if (!is.null(begin_date...  
   # bottom check for too long of duration  

--- a/R/coops.R
+++ b/R/coops.R
@@ -163,7 +163,7 @@ coops_search <- function(begin_date = NULL, end_date = NULL,
   ed <- as.Date(as.character(end_date),format="%Y%m%d")
   req_dur <- ed - bd
   if (req_dur > maxdur) {
-    stop(paste("The maximum duration NOAA API supports a single call for ", product, " is ", maxdur, "days\n", 
+    stop(paste("The maximum duration NOAA API supports a single call for\n", product, " is ", maxdur, " days\n", 
                begin_date, " to ", end_date, " is ", req_dur, " days\n",sep=""), call. = FALSE)
   }
   # bottom check for too long of duration  

--- a/R/coops.R
+++ b/R/coops.R
@@ -159,13 +159,15 @@ coops_search <- function(begin_date = NULL, end_date = NULL,
     maxdur <- 3653
   } else maxdur <- 365000
   
-  bd <- as.Date(as.character(begin_date),format="%Y%m%d")
-  ed <- as.Date(as.character(end_date),format="%Y%m%d")
-  req_dur <- ed - bd
-  if (req_dur > maxdur) {
-    stop(paste("The maximum duration NOAA API supports a single call for\n", product, " is ", maxdur, " days\n", 
-               begin_date, " to ", end_date, " is ", req_dur, " days\n",sep=""), call. = FALSE)
-  }
+  if (!is.null(begin_date)&!is.null(end_date)) {
+    bd <- as.Date(as.character(begin_date),format="%Y%m%d")
+    ed <- as.Date(as.character(end_date),format="%Y%m%d")
+    req_dur <- ed - bd
+    if (req_dur > maxdur) {
+      stop(paste("The maximum duration NOAA API supports a single call for\n", product, " is ", maxdur, " days\n", 
+                 begin_date, " to ", end_date, " is ", req_dur, " days\n",sep=""), call. = FALSE)
+    } # if (req_dur > maxdur)
+  } # if (!is.null(begin_date...  
   # bottom check for too long of duration  
     
   args <- noaa_compact(list(begin_date = begin_date, end_date = end_date,

--- a/R/coops.R
+++ b/R/coops.R
@@ -145,7 +145,7 @@ coops_search <- function(begin_date = NULL, end_date = NULL,
   group1_products <- c(                       # sub-hourly products with 31 day max
     "water_level",  "air_temperature",  "water_temperature",  "wind", 
     "air_pressure", "air_gap", "conductivity", "visibility", "humidity", 
-    "salinity", "one_minute_water_level", "predictions")
+    "salinity", "one_minute_water_level", "predictions", "currents")
                         
   group2_products <- c(                       # hourly to sub-daily products with 1 year max
     "hourly_height", "high_low")

--- a/R/coops.R
+++ b/R/coops.R
@@ -146,7 +146,7 @@ coops_search <- function(begin_date = NULL, end_date = NULL,
     "water_level",  "air_temperature",  "water_temperature",  "wind", 
     "air_pressure", "air_gap", "conductivity", "visibility", "humidity", 
     "salinity", "one_minute_water_level", "predictions")
-                        )
+                        
   group2_products <- c(                       # hourly to sub-daily products with 1 year max
     "hourly_height", "high_low")
   group3_products <- c(                       # daily or longer products with 10 year max

--- a/tests/testthat/test-coops.R
+++ b/tests/testthat/test-coops.R
@@ -42,3 +42,25 @@ test_that("coops fails well", {
   
 })
 
+test_that("coops fails well", {
+  skip_on_cran()
+  skip_on_travis()
+  skip_on_appveyor()
+  
+  expect_error(coops_search(station_name = 8724580, begin_date = 20040927, end_date = 20140928,
+ product = "high_low", datum = "stnd"), "The maximum duration NOAA API") 
+  
+})
+
+
+test_that("coops fails well", {
+  skip_on_cran()
+  skip_on_travis()
+  skip_on_appveyor()
+  
+  expect_error(coops_search(station_name = "ps0401", begin_date = 20151121, end_date = 20151231,
+ product = "currents"), "The maximum duration NOAA API") 
+  
+})
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1) Added trapping for begin_date and end_date combinations requesting longer durations than the NOAA API will accept for that product.  Instead of returning generic (and incorrect or at least misleading) "No data found", coops_search() now fails with an informative error message.

2) Re-ordered product item order into 31-day max, 1 year max, 10 year max, and no dates (datums) and added block of text noting the maximum durations in single calls.  I DID NOT TEST WHETHER THIS RENDS CORRECTLY!  Please check before accepting the pull request.

3) Added 2 tests at bottom of tests/testthat/test-coops.R.  My full test suite includes a pair of calls for each product, one with short duration that should return data and one with excessive duration that should throw error instead of "No data found".  I don't know your policy on exhaustiveness of tests, especially given that they all hit an external API.
## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
(Mostly) fix issue #213 
## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
```
# Get verified water level data at Vaca Key (8723970)
# duration < 31 days Returns data
coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20140928,
 datum = "stnd", product = "water_level")
# duration > 31 days fails with new error message
coops_search(station_name = 8723970, begin_date = 20140927, end_date = 20141128,
 datum = "stnd", product = "water_level")
```
<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
2 tests added to tests-coops.R