### PR TITLE
Update rnoaa_ropenaq.Rmd

### DIFF
--- a/inst/vign/rnoaa_ropenaq.Rmd
+++ b/inst/vign/rnoaa_ropenaq.Rmd
@@ -10,43 +10,44 @@ __Author__ Maëlle Salmon
 
 # Introduction: getting air quality data
 
-This vignette aims at explaining how you can complement a data.frame with weather data using rnoaa. In this vignette we shall use air quality data from the OpenAQ platform queried with the ropenaq package, for India. Using [ropenaq](https://github.com/ropensci/ropenaq) one can get e.g. PM2.5 values over time in Delhi in March 2016. For getting all data for march we'll loop over several pages.
+This vignette aims at explaining how you can complement a data.frame with weather data using rnoaa. In this vignette we shall use air quality data from the OpenAQ platform queried with the ropenaq package, for India. Using [ropenaq](https://github.com/ropensci/ropenaq) one can get e.g. PM2.5 values over time in Indianapolis over the last days. For getting all data for march we'll loop over several pages.
 
-First, we need to know how many measures are available for Delhi for March 2016.
+First, we need to know how many measures are available for Indianapolis for March 2016.
 
 ```{r, message = FALSE, warning = FALSE, eval = FALSE, echo = TRUE}
 library("ropenaq")
 
-measurementsDelhi <- aq_measurements(city = "Delhi", parameter = "pm25",
-                                     date_from = "2016-03-01",
-                                     date_to = "2016-03-31")
-
-save(measurementsDelhi, file = "data/measurementsDelhi.RData")
+measurementsIndianapolis <- aq_measurements(city = "Indianapolis", parameter = "pm25",
+                                     date_from = as.character(Sys.Date() - 30),
+                                     date_to = as.character(Sys.Date()),
+                                     limit = 10000 )
+save(measurementsIndianapolis, file = "data/measurementsIndianapolis.RData")
 ```
 
 We filter negative values.
 
 ```{r, message = FALSE, warning = FALSE, eval = TRUE, echo = TRUE}
+
+load("data/measurementsIndianapolis.RData")
 library("dplyr")
-load("data/measurementsDelhi.RData")
-measurementsDelhi %>% head() %>% knitr::kable()
-measurementsDelhi <- filter(measurementsDelhi, value > 0)
+measurementsIndianapolis %>% head() %>% knitr::kable()
+measurementsIndianapolis <- filter(measurementsIndianapolis, value > 0)
 ```
 
 We now transform these data into daily data.
 
 ```{r, message = FALSE, warning = FALSE}
 # only keep stations with geographical information
-measurementsDelhi <- filter(measurementsDelhi, !is.na(latitude))
+measurementsIndianapolis <- filter(measurementsIndianapolis, !is.na(latitude))
 # now transform to daily data
-measurementsDelhi <- measurementsDelhi %>%
+measurementsIndianapolis <- measurementsIndianapolis %>%
   mutate(day = as.Date(dateLocal)) %>%
   group_by(location, day) %>%
   summarize(value = mean(value),
             longitude = longitude[1],
             latitude = latitude[1]) %>%
   ungroup()
-measurementsDelhi %>% head() %>% knitr::kable()
+measurementsIndianapolis %>% head() %>% knitr::kable()
 
 ```
 
@@ -61,7 +62,7 @@ Here we query stations with a less than 15km distance from the air quality stati
 ```{r, eval = FALSE, echo = TRUE}
 library("rnoaa")
 station_data <- ghcnd_stations()
-lat_lon_df <- select(measurementsDelhi,
+lat_lon_df <- select(measurementsIndianapolis,
                      location,
                      latitude,
                      longitude) %>% unique() %>%
@@ -69,20 +70,20 @@ lat_lon_df <- select(measurementsDelhi,
   rename(id = location) %>%
   mutate(id = factor(id))
 
-stationsDelhi <- meteo_nearby_stations(lat_lon_df = as.data.frame(lat_lon_df),
+stationsIndianapolis <- meteo_nearby_stations(lat_lon_df = as.data.frame(lat_lon_df),
                                        station_data = station_data,
-                                       radius = 15,
-                                       year_min = 2016,
+                                       radius = 5,
+                                       year_min = as.character(format(Sys.Date(), "%Y")),
                                        var = c("TAVG", "PRCP"))
-stationsDelhi <- unique(bind_rows(stationsDelhi) %>% select(- distance))
+stationsIndianapolis <- unique(bind_rows(stationsIndianapolis) %>% select(- distance))
 
-save(stationsDelhi, file = "data/stationsDelhi.RData")
+save(stationsIndianapolis, file = "data/stationsIndianapolis.RData")
 
 ```
 
 ```{r}
-load("data/stationsDelhi.RData")
-stationsDelhi %>% knitr::kable()
+load("data/stationsIndianapolis.RData")
+stationsIndianapolis %>% knitr::kable()
 ```
 
 Now let us plot the AQ and weather stations on a quick and dirty map with no legend, red for AQ stations, blue for weather stations.
@@ -91,12 +92,12 @@ Now let us plot the AQ and weather stations on a quick and dirty map with no leg
 
 ```{r, message = FALSE, warning = FALSE, fig.width = 10, fig.height = 10, eval=FALSE}
 library("ggmap")
-map <- get_map(location = "Delhi", zoom = 11)
+map <- get_map(location = "Indianapolis", zoom = 11)
 ggmap(map) +
   geom_point(aes(x = longitude, y = latitude),
-             data = stationsDelhi, col = "blue", size = 4)+
+             data = stationsIndianapolis, col = "blue", size = 4)+
   geom_point(aes(x = longitude, y = latitude),
-             data = measurementsDelhi, col = "red", size = 4)
+             data = measurementsIndianapolis, col = "red", size = 4)
 ```
 
 
@@ -106,10 +107,10 @@ For pulling weather data from these weather monitors, we shall use the `meteo_pu
 
 ```{r}
 library("rnoaa")
-monitors <- stationsDelhi$id
+monitors <- stationsIndianapolis$id
 all_monitors_clean <- meteo_pull_monitors(monitors,
-                                      date_min = "2016-03-01",
-                                     date_max = "2016-03-31") %>%
+                                      date_min = as.character(Sys.Date() - 30),
+                                     date_max = as.character(Sys.Date())) %>%
   rename(day = date,
          location = id)
 all_monitors_clean %>% head() %>% knitr::kable()
@@ -123,8 +124,8 @@ Here we notice some values are not available. Therefore, we might need to go bac
 Therefore, in this case we will bind the rows of the air quality table with the weather table.
 
 ```{r}
-measurementsDelhi <- bind_rows(measurementsDelhi, all_monitors_clean)
-measurementsDelhi %>% head() %>% knitr::kable()
+measurementsIndianapolis <- bind_rows(measurementsIndianapolis, all_monitors_clean)
+measurementsIndianapolis %>% head() %>% knitr::kable()
 ```
 
 
@@ -133,10 +134,11 @@ measurementsDelhi %>% head() %>% knitr::kable()
 We can plot the data we got.
 
 ```{r, fig.width = 10, fig.height = 5, warning = FALSE}
-data_plot <- measurementsDelhi %>%
+data_plot <- measurementsIndianapolis %>%
   rename(pm25 = value) %>%
-  select(- longitude, - latitude, - tmax, - tmin) %>%
-  tidyr::gather(parameter, value, pm25:prcp)
+  select(- longitude, - latitude)
+
+data_plot <- tidyr::gather_(data_plot, "parameter", "value",           names(data_plot)[3:ncol(data_plot)])
 
 library("ggplot2")
 ggplot(data_plot) +


### PR DESCRIPTION
Because the API now only provides data for the last 90 days, the old examples did not work. Now it works but the NOAA vs OpenAQ data availabilities were not interesting for Delhi. I tried a new city, the end graph is not that interesting but it does show the workflow. Could you build the vignette (using ropenaq dev version because I'll now submit it to CRAN so it's not there yet) and update the data in inst/vign/data?