### PR TITLE
Update README

### DIFF
--- a/R/rnoaa-package.r
+++ b/R/rnoaa-package.r
@@ -88,13 +88,23 @@
 #'
 #' @section A note about NCDF data:
 #'
-#' Functions to work with buoy data use netcdf files. You'll need the
-#' \code{ncdf4} package for those functions, and those only. \code{ncdf4} is
-#' in Suggests in this package, meaning you only need \code{ncdf4} if you are
-#' using the buoy functions. You'll get an informative error telling you to
-#' install \code{ncdf4} if you don't have it and you try to use the
-#' buoy functions.
-
+#' Some functions use netcdf files, including:
+#' 
+#' \itemize{
+#'  \item \code{gefs}
+#'  \item \code{ersst}
+#'  \item \code{buoy}
+#'  \item \code{bsw}
+#'  \item \code{argo}
+#' }
+#'  
+#' You'll need the \code{ncdf4} package for those functions, and those only.
+#' \code{ncdf4} is in Suggests in this package, meaning you only need 
+#' \code{ncdf4} if you are using any of the functions listed above. You'll get 
+#' an informative error telling you to install \code{ncdf4} if you don't have 
+#' it and you try to use the those functions. Installation of \code{ncdf4} 
+#' should be straightforward on any system.
+#'
 #' @section The \code{meteo} family of functions:
 #'
 #' The \code{meteo} family of functions are prefixed with \code{meteo_} and

--- a/README.Rmd
+++ b/README.Rmd
@@ -92,7 +92,15 @@ There is a tutorial on the [rOpenSci website](http://ropensci.org/tutorials/rnoa
 
 ## netcdf data
 
-Functions to work with buoy data use netcdf files. You'll need the `ncdf4` package for those functions, and those only. `ncdf4` is in Suggests in this package, meaning you only need `ncdf4` if you are using the buoy functions. You'll get an informative error telling you to install `ncdf4` if you don't have it and you try to use the buoy functions. Installation of `ncdf4` should be straightforward. See https://cran.r-project.org/package=ncdf4.
+Some functions use netcdf files, including:
+
+* `gefs`
+* `ersst`
+* `buoy`
+* `bsw`
+* `argo`
+ 
+You'll need the `ncdf4` package for those functions, and those only. `ncdf4` is in Suggests in this package, meaning you only need `ncdf4` if you are using any of the functions listed above. You'll get an informative error telling you to install `ncdf4` if you don't have it and you try to use the those functions. Installation of `ncdf4` should be straightforward on any system. See https://cran.r-project.org/package=ncdf4.
 
 ## NOAA NCDC Datasets
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -92,7 +92,7 @@ There is a tutorial on the [rOpenSci website](http://ropensci.org/tutorials/rnoa
 
 ## netcdf data
 
-Functions to work with buoy data use netcdf files. You'll need the `ncdf` package for those functions, and those only. `ncdf` is in Suggests in this package, meaning you only need `ncdf` if you are using the buoy functions. You'll get an informative error telling you to install `ncdf` if you don't have it and you try to use the buoy functions. Installation of `ncdf` should be straightforward on Mac and Windows, but on Linux you may have issues. See http://cran.r-project.org/web/packages/ncdf/INSTALL
+Functions to work with buoy data use netcdf files. You'll need the `ncdf4` package for those functions, and those only. `ncdf4` is in Suggests in this package, meaning you only need `ncdf4` if you are using the buoy functions. You'll get an informative error telling you to install `ncdf4` if you don't have it and you try to use the buoy functions. Installation of `ncdf4` should be straightforward. See https://cran.r-project.org/package=ncdf4.
 
 ## NOAA NCDC Datasets
 

--- a/README.md
+++ b/README.md
@@ -81,13 +81,21 @@ or [on CRAN](https://cran.r-project.org/package=rnoaa). The tutorials:
 
 ## netcdf data
 
-Functions to work with buoy data use netcdf files. You’ll need the
-`ncdf4` package for those functions, and those only. `ncdf4` is in
-Suggests in this package, meaning you only need `ncdf4` if you are using
-the buoy functions. You’ll get an informative error telling you to
-install `ncdf4` if you don’t have it and you try to use the buoy
-functions. Installation of `ncdf4` should be straightforward.
-See https://cran.r-project.org/package=ncdf4
+Some functions use netcdf files, including:
+
+  -  `gefs`
+  - `ersst`
+  - `buoy`
+  - `bsw`
+  - `argo`
+ 
+You'll need the `ncdf4` package for those functions, and those only.
+`ncdf4` is in Suggests in this package, meaning you only need `ncdf4`
+if you are using any of the functions listed above. You'll get an 
+informative error telling you to install `ncdf4` if you don't have it
+and you try to use the those functions. Installation of `ncdf4` should
+be straightforward on any system. See 
+https://cran.r-project.org/package=ncdf4.
 
 ## NOAA NCDC Datasets
 

--- a/README.md
+++ b/README.md
@@ -82,13 +82,12 @@ or [on CRAN](https://cran.r-project.org/package=rnoaa). The tutorials:
 ## netcdf data
 
 Functions to work with buoy data use netcdf files. You’ll need the
-`ncdf` package for those functions, and those only. `ncdf` is in
-Suggests in this package, meaning you only need `ncdf` if you are using
+`ncdf4` package for those functions, and those only. `ncdf4` is in
+Suggests in this package, meaning you only need `ncdf4` if you are using
 the buoy functions. You’ll get an informative error telling you to
-install `ncdf` if you don’t have it and you try to use the buoy
-functions. Installation of `ncdf` should be straightforward on Mac and
-Windows, but on Linux you may have issues. See
-<http://cran.r-project.org/web/packages/ncdf/INSTALL>
+install `ncdf4` if you don’t have it and you try to use the buoy
+functions. Installation of `ncdf4` should be straightforward.
+See https://cran.r-project.org/package=ncdf4
 
 ## NOAA NCDC Datasets
 

--- a/man/rnoaa-package.Rd
+++ b/man/rnoaa-package.Rd
@@ -99,12 +99,22 @@ during a shutdown let us know.
 \section{A note about NCDF data}{
 
 
-Functions to work with buoy data use netcdf files. You'll need the
-\code{ncdf4} package for those functions, and those only. \code{ncdf4} is
-in Suggests in this package, meaning you only need \code{ncdf4} if you are
-using the buoy functions. You'll get an informative error telling you to
-install \code{ncdf4} if you don't have it and you try to use the
-buoy functions.
+Some functions use netcdf files, including:
+
+\itemize{
+ \item \code{gefs}
+ \item \code{ersst}
+ \item \code{buoy}
+ \item \code{bsw}
+ \item \code{argo}
+}
+ 
+You'll need the \code{ncdf4} package for those functions, and those only.
+\code{ncdf4} is in Suggests in this package, meaning you only need 
+\code{ncdf4} if you are using any of the functions listed above. You'll get 
+an informative error telling you to install \code{ncdf4} if you don't have 
+it and you try to use the those functions. Installation of \code{ncdf4} 
+should be straightforward on any system.
 }
 
 \section{The \code{meteo} family of functions}{


### PR DESCRIPTION
Update README

<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated README to link to ncdf4 instead of ncdf which don't exist anymore on CRAN.
Also, I haven't encounter any problem to install ncdf4 on Linux.

## Related Issue
#117 
