### PR TITLE
Update tornadoes URL and add tests

### DIFF
--- a/R/tornadoes.R
+++ b/R/tornadoes.R
@@ -29,10 +29,10 @@ tornadoes <- function(overwrite = TRUE, ...) {
   check4pkg('rgdal')
   path <- file.path(rnoaa_cache_dir(), "tornadoes")
   if (!is_tornadoes(path)) {
-    url <- 'https://www.spc.noaa.gov/gis/svrgis/zipped/tornado.zip'
+    url <- 'https://www.spc.noaa.gov/gis/svrgis/zipped/1950-2017-torn-aspath.zip'
     tornadoes_GET(path, url, overwrite, ...)
   }
-  readshp(file.path(path, "torn"))
+  readshp(file.path(path, tornadoes_basename))
 }
 
 tornadoes_GET <- function(bp, url, overwrite, ...){
@@ -55,8 +55,10 @@ is_tornadoes <- function(x){
   }
 }
 
-readshp <- function(x) rgdal::readOGR(dsn = path.expand(x), layer = "torn",
+tornadoes_basename <- "1950-2017-torn-aspath"
+
+readshp <- function(x) rgdal::readOGR(dsn = path.expand(x),
+                                      layer = tornadoes_basename,
                                       stringsAsFactors = FALSE)
 
-tornadoes_files <-
-  c("torn.dbf","torn.prj","torn.cpg","torn.shp","torn.shx")
+tornadoes_files <- paste0(tornadoes_basename, c(".dbf", ".prj", ".shp", ".shx"))

--- a/R/tornadoes.R
+++ b/R/tornadoes.R
@@ -1,5 +1,8 @@
 #' Get NOAA tornado data.
 #'
+#' This function gets spatial paths of tornadoes from NOAA's National Weather
+#' Service Storm Prediction Center Severe Weather GIS web page.
+#'
 #' @export
 #' @param overwrite (logical) To overwrite the path to store files in or not,
 #' Default: `TRUE`

--- a/man/tornadoes.Rd
+++ b/man/tornadoes.Rd
@@ -16,7 +16,8 @@ Default: \code{TRUE}}
 A Spatial object is returned of class SpatialLinesDataFrame.
 }
 \description{
-Get NOAA tornado data.
+This function gets spatial paths of tornadoes from NOAA's National Weather
+Service Storm Prediction Center Severe Weather GIS web page.
 }
 \section{File storage}{
 

--- a/tests/testthat/test-tornadoes.R
+++ b/tests/testthat/test-tornadoes.R
@@ -1,0 +1,9 @@
+context("tornadoes")
+
+test_that("tornadoes works", {
+  skip_on_cran()
+  skip_if_government_down()
+
+  expect_warning(torn <- tornadoes(), regexp = "Dropping null geometries")
+  expect_is(torn, "SpatialLinesDataFrame")
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses #311 by updating the URL for tornado path data. The current URL returns a 403 status code.

I also added an object `tornadoes_basename` instead of repeating it multiple places, to make a similar fix slightly easier in the future, if the URL changes again. 

Finally, this adds a test for `rnoaa::tornadoes()`. One small hiccup is that the shapefile served by the current URL contains empty geometries, which raises a warning when reading with `rgdal::readOGR()`. To deal with this, I added an `expect_warning` call to the test, but there may be a more elegant way to handle this expectation. 


## Related Issue

This is related to #208, which mentions that the `rnoaa::tornadoes()` function lacks tests. 

## Example

Usage of the `tornadoes()` function is unchanged by this PR. It is still:

```r
library(rnoaa)
shp <- tornadoes()
```
