### PR TITLE
Add notes about units in ncdc responses

### DIFF
--- a/R/ncdc.r
+++ b/R/ncdc.r
@@ -77,7 +77,10 @@
 #'
 #' @return An S3 list of length two, a slot of metadata (meta), and a slot
 #' for data (data). The meta slot is a list of metadata elements, and the
-#' data slot is a data.frame, possibly of length zero if no data is found.
+#' data slot is a data.frame, possibly of length zero if no data is found. Note
+#' that values in the data slot don't indicate their units so you will want to
+#' consult the documentation for each dataset to ensure you're using the right
+#' units.
 #'
 #' @family ncdc
 #'

--- a/R/ncdc.r
+++ b/R/ncdc.r
@@ -78,9 +78,10 @@
 #' @return An S3 list of length two, a slot of metadata (meta), and a slot
 #' for data (data). The meta slot is a list of metadata elements, and the
 #' data slot is a data.frame, possibly of length zero if no data is found. Note
-#' that values in the data slot don't indicate their units so you will want to
-#' consult the documentation for each dataset to ensure you're using the right
-#' units.
+#' that values in the data slot don't indicate their units by default, so you
+#' will want to either use the `add_units` parameter (experimental, see Adding
+#' units) or consult the documentation for each dataset to ensure you're using
+#' the correct units.
 #'
 #' @family ncdc
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -203,12 +203,19 @@ out <- ncdc(datasetid='NORMAL_DLY', stationid='GHCND:USW00014895', datatypeid='d
 head( out$data )
 ```
 
+Note that the `value` column has strangely large numbers for temperature measurements.
+By convention, the `rnoaa` package doesn't do any conversion of values from the APIs and some APIs use seemingly odd units.
+In this case, `TMAX` values from `GHCND` are in tenths of degrees Celcius which is a unit you'll see elsewhere when working with NOAA data.
+See [the GHCN-DAILY README](https://www1.ncdc.noaa.gov/pub/data/ghcn/daily/readme.txt) for more information.
+
 ### Plot data, super simple, but it's a start
 
 ```{r}
 out <- ncdc(datasetid='GHCND', stationid='GHCND:USW00014895', datatypeid='PRCP', startdate = '2010-05-01', enddate = '2010-10-31', limit=500)
 ncdc_plot(out, breaks="1 month", dateformat="%d/%m")
 ```
+
+Note that `PRCP` values are in units of tenths of a millimeter.
 
 ### More plotting
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -204,9 +204,25 @@ head( out$data )
 ```
 
 Note that the `value` column has strangely large numbers for temperature measurements.
-By convention, the `rnoaa` package doesn't do any conversion of values from the APIs and some APIs use seemingly odd units.
-In this case, `TMAX` values from `GHCND` are in tenths of degrees Celcius which is a unit you'll see elsewhere when working with NOAA data.
-See [the GHCN-DAILY README](https://www1.ncdc.noaa.gov/pub/data/ghcn/daily/readme.txt) for more information.
+By convention, `rnoaa` doesn't do any conversion of values from the APIs and some APIs use seemingly odd units.
+
+You have two options here:
+
+1. Use the `add_units` parameter on `ncdc` to have `rnoaa` attempt to look up the units. This is a good idea to try first.
+
+2. Consult the documentation for whiechever dataset you're accessing. In this case, `GHCND` has a [README](https://www1.ncdc.noaa.gov/pub/data/ghcn/daily/readme.txt) which indicates `TMAX` is measured in tenths of degrees Celcius.
+
+### See a `data.frame` with units
+
+As mentioned above, you can use the `add_units` parameter with `ncdc()` to ask `rnoaa` to attempt to look up units for whatever data you ask it to return.
+Let's ask `rnoaa` to add units to some precipitation (PRCP) data:
+
+```{r}
+with_units <- ncdc(datasetid='GHCND', stationid='GHCND:USW00014895', datatypeid='PRCP', startdate = '2010-05-01', enddate = '2010-10-31', limit=500, add_units = TRUE)
+head( with_units$data )
+```
+From the above output, we can see that the units for `PRCP` values are "mm_tenths" which means tenths of a millimeter.
+You won't always be so lucky and sometimes you will have to look up the documentation on your own.
 
 ### Plot data, super simple, but it's a start
 
@@ -215,7 +231,7 @@ out <- ncdc(datasetid='GHCND', stationid='GHCND:USW00014895', datatypeid='PRCP',
 ncdc_plot(out, breaks="1 month", dateformat="%d/%m")
 ```
 
-Note that `PRCP` values are in units of tenths of a millimeter.
+Note that `PRCP` values are in units of tenths of a millimeter, as we found out above.
 
 ### More plotting
 

--- a/man/ncdc.Rd
+++ b/man/ncdc.Rd
@@ -90,7 +90,10 @@ for more}
 \value{
 An S3 list of length two, a slot of metadata (meta), and a slot
 for data (data). The meta slot is a list of metadata elements, and the
-data slot is a data.frame, possibly of length zero if no data is found.
+data slot is a data.frame, possibly of length zero if no data is found. Note
+that values in the data slot don't indicate their units so you will want to
+consult the documentation for each dataset to ensure you're using the right
+units.
 }
 \description{
 Search for and get NOAA NCDC data

--- a/man/ncdc.Rd
+++ b/man/ncdc.Rd
@@ -91,9 +91,10 @@ for more}
 An S3 list of length two, a slot of metadata (meta), and a slot
 for data (data). The meta slot is a list of metadata elements, and the
 data slot is a data.frame, possibly of length zero if no data is found. Note
-that values in the data slot don't indicate their units so you will want to
-consult the documentation for each dataset to ensure you're using the right
-units.
+that values in the data slot don't indicate their units by default, so you
+will want to either use the \code{add_units} parameter (experimental, see Adding
+units) or consult the documentation for each dataset to ensure you're using
+the correct units.
 }
 \description{
 Search for and get NOAA NCDC data

--- a/vignettes/ncdc_vignette.Rmd
+++ b/vignettes/ncdc_vignette.Rmd
@@ -61,6 +61,11 @@ out$data
 #> # … with 15 more rows
 ```
 
+Note that the `value` column has strangely large numbers for temperature measurements.
+By convention, the `rnoaa` package doesn't do any conversion of values from the APIs and some APIs use seemingly odd units.
+In this case, `TMAX` values from `GHCND` are in tenths of degrees Celcius which is a unit you'll see elsewhere when working with NOAA data.
+See [the GHCN-DAILY README](https://www1.ncdc.noaa.gov/pub/data/ghcn/daily/readme.txt) for more information.
+
 ## Plot data, super simple, but it's a start
 
 

--- a/vignettes/ncdc_vignette.Rmd
+++ b/vignettes/ncdc_vignette.Rmd
@@ -62,9 +62,25 @@ out$data
 ```
 
 Note that the `value` column has strangely large numbers for temperature measurements.
-By convention, the `rnoaa` package doesn't do any conversion of values from the APIs and some APIs use seemingly odd units.
-In this case, `TMAX` values from `GHCND` are in tenths of degrees Celcius which is a unit you'll see elsewhere when working with NOAA data.
-See [the GHCN-DAILY README](https://www1.ncdc.noaa.gov/pub/data/ghcn/daily/readme.txt) for more information.
+By convention, `rnoaa` doesn't do any conversion of values from the APIs and some APIs use seemingly odd units.
+
+You have two options here:
+
+1. Use the `add_units` parameter on `ncdc()` to have `rnoaa` attempt to look up the units. This is a good idea to try first.
+
+2. Consult the documentation for whiechever dataset you're accessing. In this case, `GHCND` has a [README](https://www1.ncdc.noaa.gov/pub/data/ghcn/daily/readme.txt) which indicates `TMAX` is measured in tenths of degrees Celcius.
+
+### See a `data.frame` with units
+
+As mentioned above, you can use the `add_units` parameter with `ncdc()` to ask `rnoaa` to attempt to look up units for whatever data you ask it to return.
+Let's ask `rnoaa` to add units to some precipitation (PRCP) data:
+
+```{r}
+with_units <- ncdc(datasetid='GHCND', stationid='GHCND:USW00014895', datatypeid='PRCP', startdate = '2010-05-01', enddate = '2010-10-31', limit=500, add_units = TRUE)
+head( with_units$data )
+```
+From the above output, we can see that the units for `PRCP` values are "mm_tenths" which means tenths of a millimeter.
+You won't always be so lucky and sometimes you will have to look up the documentation on your own.
 
 ## Plot data, super simple, but it's a start
 
@@ -73,6 +89,8 @@ See [the GHCN-DAILY README](https://www1.ncdc.noaa.gov/pub/data/ghcn/daily/readm
 out <- ncdc(datasetid='NORMAL_DLY', stationid='GHCND:USW00014895', datatypeid='dly-tmax-normal', startdate = '2010-01-01', enddate = '2010-12-10', limit = 300)
 ncdc_plot(out)
 ```
+
+Note that `PRCP` values are in units of tenths of a millimeter, as we found out above.
 
 ![plot of chunk six](figure/six-1.png)
 


### PR DESCRIPTION
Addresses #265

As per #265, I added some notes in relevant places warning users about odd units.

## Description

Adds notes in:

- README
- `ncdc` vignette
- `ncdc` docs

## Related Issue

#265 


## Notes

I couldn't get the README to knit or the vignettes to build (or tests to run), so I haven't done that here.
