### PR TITLE
Update tornado paths url

### DIFF
--- a/R/tornadoes.R
+++ b/R/tornadoes.R
@@ -21,7 +21,7 @@
 #' shp <- tornadoes()
 #' library('sp')
 #' if (interactive()) {
-#'   # may take 10 sec or so to render 
+#'   # may take 10 sec or so to render
 #'   plot(shp)
 #' }
 #' }
@@ -35,7 +35,7 @@ tornadoes <- function(overwrite = TRUE, ...) {
   check4pkg('rgdal')
   path <- file.path(rnoaa_cache_dir(), "tornadoes")
   if (!is_tornadoes(path)) {
-    url <- 'https://www.spc.noaa.gov/gis/svrgis/zipped/1950-2017-torn-aspath.zip'
+    url <- 'https://www.spc.noaa.gov/gis/svrgis/zipped/1950-2018-torn-aspath.zip'
     tornadoes_GET(path, url, overwrite, ...)
   }
   readshp(file.path(path, tornadoes_basename))
@@ -61,7 +61,7 @@ is_tornadoes <- function(x){
   }
 }
 
-tornadoes_basename <- "1950-2017-torn-aspath"
+tornadoes_basename <- "1950-2018-torn-aspath"
 
 readshp <- function(x) rgdal::readOGR(dsn = path.expand(x),
                                       layer = tornadoes_basename,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The data for 2018 were recently added to the NOAA tornado paths, and the old file was removed, which broke the `tornadoes()` function. This PR updates the URL to reflect the new data.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

Closes  #322

## Example

The behavior is the same as before:

```r
library(rnoaa)
torn <- tornadoes()
```