### PR TITLE
Added hoardr mkdir() call to make sure cache path exists for ghcnd_stations() call

### DIFF
--- a/R/ghcnd.R
+++ b/R/ghcnd.R
@@ -311,6 +311,7 @@ get_stations <- function(refresh = FALSE, ...) {
   } else {
     if (file.exists(ff)) unlink(ff)
     if (file.exists(ffrds)) unlink(ffrds)
+    ghcnd_cache$mkdir()
     res <- GET_retry(
       "ftp://ftp.ncdc.noaa.gov/pub/data/ghcn/daily/ghcnd-stations.txt",
       disk = ff, ...)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix `ghcnd_stations()` error.

## Description
<!--- Describe your changes in detail -->
This fixes the problem where a new `ghcnd_stations()` call cannot write a local dump of the stations data in the `hoardr` cache.  I added a single line before the GET call to write the data locally to create the cache directory if it doesn't exist, according to what I read about `hoardr`.  The call now works.

I am unsure if this is the appropriate place to place the `mkdir()` cache creation call, but it is a place that will work for the limited scope call of `ghcnd_stations()`.


## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
Fix #349 
